### PR TITLE
Upload the AOT binaries in test CI

### DIFF
--- a/.github/workflows/aot-test.yml
+++ b/.github/workflows/aot-test.yml
@@ -29,3 +29,9 @@ jobs:
         env:
           DEV_BUILD: true
         run: sbt GraalVMNativeImage/packageBin
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: jelly-cli-${{ matrix.os }}
+          path: target/graalvm-native-image/*


### PR DESCRIPTION
After compiling the AOT binaries for testing in a PR CI run, upload them as artifacts. This will make it more convenient for people to experiment with AOT compilation without setting up a toolchain locally.