### PR TITLE
Lower used OS versions in CI

### DIFF
--- a/.github/workflows/aot-publish.yml
+++ b/.github/workflows/aot-publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-14, windows-2022, ubuntu-24.04, ubuntu-24.04-arm]
+        os: [macos-14, windows-2019, ubuntu-22.04, ubuntu-22.04-arm]
     steps:
       - uses: actions/checkout@v4
 
@@ -42,9 +42,9 @@ jobs:
       - name: Rename binaries
         run: |
           mv jelly-cli-macos-14/jelly-cli jelly-cli-mac-arm64
-          mv jelly-cli-ubuntu-24.04/jelly-cli jelly-cli-linux-x86_64
-          mv jelly-cli-ubuntu-24.04-arm/jelly-cli jelly-cli-linux-arm64
-          mv jelly-cli-windows-2022/jelly-cli.exe jelly-cli-windows-x86_64.exe
+          mv jelly-cli-ubuntu-22.04/jelly-cli jelly-cli-linux-x86_64
+          mv jelly-cli-ubuntu-22.04-arm/jelly-cli jelly-cli-linux-arm64
+          mv jelly-cli-windows-2019/jelly-cli.exe jelly-cli-windows-x86_64.exe
 
       - name: Upload binaries (pre-release)
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/aot-test.yml
+++ b/.github/workflows/aot-test.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # Only test on Mac and Ubuntu – these are the fastest platforms.
         # Windows and Linux ARM are built later after the PR is merged.
-        os: [macos-14, ubuntu-24.04]
+        os: [macos-14, ubuntu-22.04]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Binaries compiled on Ubuntu 24 won't run on 22. Let's lower the used OS versions as far as possible to increase compatibility.