### PR TITLE
Add simple logging provider to get rid of warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "jelly-cli",
     libraryDependencies ++= Seq(
+      "org.slf4j" % "slf4j-simple" % "2.0.17",
       "org.apache.jena" % "jena-core" % jenaV,
       "org.apache.jena" % "jena-arq" % jenaV,
       "eu.ostrzyciel.jelly" %% "jelly-jena" % jellyV,


### PR DESCRIPTION
The warning is caused by no logging provider being specified for slf4j. Added simple provider for now - seems like a better decision than just using nop explicitely, although explicit nop makes the warning disappear as well.
Issue: #26