### PR TITLE
Optimize release AOT builds for size

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,5 +47,4 @@ lazy val root = (project in file("."))
     // Do a fast build if it's a dev build
     // For the release build, optimize for size and make a build report
     graalVMNativeImageOptions := (if (isDevBuild) Seq("-Ob") else Seq("-Os", "--emit build-report")),
-    graalVMNativeImageCommand := "/opt/graalvm_2025_02/bin/native-image"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -45,5 +45,7 @@ lazy val root = (project in file("."))
     // GraalVM settings
     Compile / mainClass := Some("eu.neverblink.jelly.cli.App"),
     // Do a fast build if it's a dev build
-    graalVMNativeImageOptions := (if (isDevBuild) Seq("-Ob") else Seq("--emit build-report")),
+    // For the release build, optimize for size and make a build report
+    graalVMNativeImageOptions := (if (isDevBuild) Seq("-Ob") else Seq("-Os", "--emit build-report")),
+    graalVMNativeImageCommand := "/opt/graalvm_2025_02/bin/native-image"
   )


### PR DESCRIPTION
Issue: #28 

On Linux x86_64, this reduces the binary size from 68.65MB to **44.43 MB**. I'd say a 1/3 saving is worth it.