### PR TITLE
rdf to-jelly: add --delimited option

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ resolvers +=
   "Sonatype OSS Snapshots" at "https://s01.oss.sonatype.org/content/repositories/snapshots"
 
 lazy val jenaV = "5.3.0"
-lazy val jellyV = "2.9.1"
+lazy val jellyV = "2.9.1+8-58db074b-SNAPSHOT"
 
 addCommandAlias("fixAll", "scalafixAll; scalafmtAll")
 

--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJelly.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJelly.scala
@@ -31,6 +31,11 @@ case class RdfToJellyOptions(
         "Default: false",
     )
     enableNamespaceDeclarations: Boolean = false,
+    @HelpMessage(
+      "Whether the output should be delimited. Setting it to false will force the output to be a single " +
+        "frame – make sure you know what you are doing. Default: true",
+    )
+    delimited: Boolean = true,
 ) extends HasJellyCommandOptions
 
 object RdfToJelly extends RdfCommand[RdfToJellyOptions, RdfFormat.Jena.Readable]:
@@ -85,6 +90,7 @@ object RdfToJelly extends RdfCommand[RdfToJellyOptions, RdfFormat.Jena.Readable]
         JellyLanguage.SYMBOL_ENABLE_NAMESPACE_DECLARATIONS,
         getOptions.enableNamespaceDeclarations,
       )
+      .set(JellyLanguage.SYMBOL_DELIMITED_OUTPUT, getOptions.delimited)
     val jellyWriter = StreamRDFWriter.getWriterStream(
       outputStream,
       JellyLanguage.JELLY,


### PR DESCRIPTION
Issue: #55

Add an option that allows for emitting non-delimited Jelly data.