### PR TITLE
Upgrade Graal to 24 for AOT builds

### DIFF
--- a/.github/workflows/aot-publish.yml
+++ b/.github/workflows/aot-publish.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '23'
+          java-version: '24'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'

--- a/.github/workflows/aot-test.yml
+++ b/.github/workflows/aot-test.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '23'
+          java-version: '24'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'


### PR DESCRIPTION
Also, tidy up the part of build.sbt that works out the options to pass on to Graal.

I initially wanted to use this occasion to enable COH in Graal, but it seems they were faster than me, they are already way ahead of everyone with 4-byte headers: https://www.graalvm.org/jdk24/reference-manual/native-image/optimizations-and-performance/ObjectHeaderSize/

Nice.