### PR TITLE
Improve available RDF format printing

### DIFF
--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfValidate.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfValidate.scala
@@ -38,7 +38,7 @@ case class RdfValidateOptions(
     compareToRdfFile: Option[String] = None,
     @HelpMessage(
       "Format of the RDF file to compare the input stream to. If not specified, the format is " +
-        "inferred from the file name.",
+        "inferred from the file name. " + RdfValidatePrint.validFormatsString,
     )
     compareToFormat: Option[String] = None,
     @HelpMessage(

--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/util/RdfCommandPrintUtil.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/util/RdfCommandPrintUtil.scala
@@ -10,7 +10,7 @@ trait RdfCommandPrintUtil[F <: RdfFormat](using tt: TypeTest[RdfFormat, F]):
   /** Prints the available RDF formats to the user.
     */
   lazy val validFormatsString: String =
-    validFormats.map(RdfFormat.optionString).mkString(", ")
+    validFormats.map(RdfFormat.optionString).mkString("; ")
 
   lazy val helpMsg: String =
-    f"Possible values: ${validFormatsString}. Default format: ${defaultFormat.fullName}"
+    f"Possible values: ${validFormatsString}. Default: ${defaultFormat.fullName}"

--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/util/RdfFormat.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/util/RdfFormat.scala
@@ -62,12 +62,12 @@ object RdfFormat:
   // We do not ever want to write or read from Jelly to Jelly
   // So better not have it as Writeable or Readable, just mark that it's integrated into Jena
   case object JellyBinary extends RdfFormat.Jena:
-    override val fullName: String = "Jelly binary format"
+    override val fullName: String = "Jelly binary"
     override val cliOptions: List[String] = List("jelly")
     override val jenaLang: Lang = JellyLanguage.JELLY
 
   case object JellyText extends RdfFormat, RdfFormat.Writeable, RdfFormat.Readable:
-    override val fullName: String = "Jelly text format"
+    override val fullName: String = "Jelly text"
     override val cliOptions: List[String] = List("jelly-text")
     val extension = ".jelly.txt"
 
@@ -79,7 +79,7 @@ object RdfFormat:
   /** Returns a string representation of the option for the user.
     */
   def optionString(option: RdfFormat): String =
-    f"${option.cliOptions.map(s => f"\"${s}\"").mkString(", ")} for ${option.fullName}"
+    f"${option.fullName}: ${option.cliOptions.map(s => f"$s").mkString(", ")}"
 
   /** Finds the appropriate RdfFormat based on supplied option string.
     */


### PR DESCRIPTION
- Add the missing print-out for `rdf validate`
- Shorten the print-out and make a bit more readable by minimizing the amount of characters, separators, whatevers

Before:

![image](https://github.com/user-attachments/assets/f0243b75-da94-4ec5-ab0c-1d70d86ebb32)


After: 

![image](https://github.com/user-attachments/assets/56b8d133-da39-433c-8bf9-ebf6a244633c)

Still not perfect, but less annoying to me.
