### PR TITLE
rdf inspect: print the metadata in --per-frame

### DIFF
--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfInspect.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfInspect.scala
@@ -57,7 +57,7 @@ object RdfInspect extends JellyCommand[RdfInspectOptions]:
         frame: RdfStreamFrame,
         frameIndex: Int,
     ): FrameInfo =
-      val metrics = new FrameInfo(frameIndex)
+      val metrics = new FrameInfo(frameIndex, frame.metadata)
       frame.rows.foreach(r => metricsForRow(r, metrics))
       metrics
 

--- a/src/main/scala/eu/neverblink/jelly/cli/util/io/YamlDocBuilder.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/util/io/YamlDocBuilder.scala
@@ -40,7 +40,8 @@ class YamlDocBuilder(var currIndent: Int = 0):
             sb.append(System.lineSeparator())
             sb.append("  " * (indent + 1))
             this.build(e, indent + 1)
-            sb.append(System.lineSeparator())
+            // If we are at the root level, add a blank line for readability
+            if indent == 0 then sb.append(System.lineSeparator())
           else this.build(e, indent + 1)
           if ix != v.size - 1 then sb.append(System.lineSeparator())
         }

--- a/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfInspectSpec.scala
+++ b/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfInspectSpec.scala
@@ -1,13 +1,17 @@
 package eu.neverblink.jelly.cli.command.rdf
 
+import com.google.protobuf.ByteString
 import eu.neverblink.jelly.cli.{ExitException, InvalidJellyFile}
 import eu.neverblink.jelly.cli.command.helpers.TestFixtureHelper
+import eu.ostrzyciel.jelly.core.JellyOptions
+import eu.ostrzyciel.jelly.core.proto.v1.{RdfStreamFrame, RdfStreamRow}
 
 import scala.jdk.CollectionConverters.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.yaml.snakeyaml.Yaml
 
+import java.io.ByteArrayInputStream
 import java.util
 
 class RdfInspectSpec extends AnyWordSpec with Matchers with TestFixtureHelper:
@@ -25,6 +29,7 @@ class RdfInspectSpec extends AnyWordSpec with Matchers with TestFixtureHelper:
       val frames = parsed.get("frames").asInstanceOf[java.util.LinkedHashMap[String, Any]]
       frames.get("triple_count") should be(testCardinality)
     }
+
     "be able to return all frames separately as a valid Yaml" in withFullJellyFile(
       testCode = { j =>
         val (out, err) = RdfInspect.runTestCommand(List("rdf", "inspect", "--per-frame", j))
@@ -39,6 +44,7 @@ class RdfInspectSpec extends AnyWordSpec with Matchers with TestFixtureHelper:
       },
       frameSize = 15,
     )
+
     "handle properly separate frame metrics for a singular frame" in withFullJellyFile { j =>
       val (out, err) = RdfInspect.runTestCommand(List("rdf", "inspect", "--per-frame", j))
       val yaml = new Yaml()
@@ -50,6 +56,7 @@ class RdfInspectSpec extends AnyWordSpec with Matchers with TestFixtureHelper:
       frames.length should be(1)
       frames.map(_.get("triple_count")).sum should be(testCardinality)
     }
+
     "handle properly frame count when aggregating multiple frames" in withFullJellyFile(
       testCode = { j =>
         val (out, err) = RdfInspect.runTestCommand(List("rdf", "inspect", j))
@@ -65,6 +72,25 @@ class RdfInspectSpec extends AnyWordSpec with Matchers with TestFixtureHelper:
       },
       frameSize = 15,
     )
+
+    "print frame metadata in --per-frame" in {
+      val inFrame = RdfStreamFrame(
+        rows = Seq(RdfStreamRow(JellyOptions.bigGeneralized)),
+        metadata = Map("key" -> ByteString.fromHex("1337ff")),
+      )
+      val inBytes = inFrame.toByteArray
+      RdfInspect.setStdIn(ByteArrayInputStream(inBytes))
+      val (out, err) = RdfInspect.runTestCommand(List("rdf", "inspect", "--per-frame"))
+      val yaml = new Yaml()
+      val parsed = yaml.load(out).asInstanceOf[java.util.Map[String, Any]]
+      val frame0 =
+        parsed.get("frames").asInstanceOf[util.ArrayList[util.HashMap[String, Any]]].get(0)
+      frame0.get("frame_index") should be(0)
+      frame0.get("metadata") should not be None
+      val metadata = frame0.get("metadata").asInstanceOf[util.HashMap[String, String]]
+      metadata.get("key") should be("1337ff")
+    }
+
     "throw an error if the input file is not a valid Jelly file" in withEmptyJellyFile { j =>
       val exception = intercept[ExitException] {
         RdfInspect.runTestCommand(List("rdf", "inspect", j, "--debug"))


### PR DESCRIPTION
This makes the `rdf inspect` command print the contents of the metadata map, with values formatted in hex, because there is no guarantee it's actually valid UTF-8.