### PR TITLE
Fix the problem of logical type not propagating properly

### DIFF
--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJelly.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJelly.scala
@@ -129,8 +129,7 @@ object RdfToJelly extends RdfSerDesCommand[RdfToJellyOptions, RdfFormat.Readable
           .set(
             JellyLanguage.SYMBOL_ENABLE_NAMESPACE_DECLARATIONS,
             getOptions.enableNamespaceDeclarations,
-          )
-          .set(JellyLanguage.SYMBOL_DELIMITED_OUTPUT, getOptions.delimited)
+          ).set(JellyLanguage.SYMBOL_DELIMITED_OUTPUT, getOptions.delimited)
         StreamRDFWriter.getWriterStream(
           outputStream,
           JellyLanguage.JELLY,

--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJelly.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJelly.scala
@@ -121,11 +121,10 @@ object RdfToJelly extends RdfSerDesCommand[RdfToJellyOptions, RdfFormat.Readable
       else
         // TRIPLES or QUADS
         if jellyOpt.physicalType.isUnspecified then
-          if !isQuietMode && isLogicalComplex(jellyOpt) then
+          if !isQuietMode && isLogicalGrouped(jellyOpt) then
             printLine(
-              "WARNING: The physical type is unspecified, but the logical type is complex and requires framing. " +
-                "This may lead to unexpected results. " +
-                "Please specify the physical type explicitly. " +
+              "WARNING: Logical type setting ignored because physical type is not set. " +
+                "Set the physical type to properly pass on the logical type." +
                 "Use --quiet to silence this warning.",
               true,
             )
@@ -181,13 +180,13 @@ object RdfToJelly extends RdfSerDesCommand[RdfToJellyOptions, RdfFormat.Readable
       }
     }
 
-  /** Check if the logical type is more complex than FLAT_TRIPLES or FLAT_QUADS.
+  /** Check if the logical type is defined and grouped.
     * @param jellyOpt
     *   the Jelly options
     * @return
     *   true if the logical type is specified and expects framing
     */
-  private def isLogicalComplex(
+  private def isLogicalGrouped(
       jellyOpt: RdfStreamOptions,
   ): Boolean =
     !(jellyOpt.logicalType.isFlatQuads || jellyOpt.logicalType.isFlatTriples || jellyOpt.logicalType.isUnspecified)

--- a/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJellySpec.scala
+++ b/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJellySpec.scala
@@ -227,6 +227,35 @@ class RdfToJellySpec extends AnyWordSpec with TestFixtureHelper with Matchers:
         }
       }
 
+      "a file to file, modified logical type to LOGICAL_STREAM_TYPE_GRAPHS" in withFullJenaFile {
+        f =>
+          withEmptyJellyFile { j =>
+            val (out, err) =
+              RdfToJelly.runTestCommand(
+                List(
+                  "rdf",
+                  "to-jelly",
+                  f,
+                  "--opt.logical-type=GRAPHS",
+                  "--to",
+                  j,
+                ),
+              )
+            val content = translateJellyBack(new FileInputStream(j))
+            content.containsAll(DataGenHelper.generateTripleModel(testCardinality).listStatements())
+            val frames = readJellyFile(new FileInputStream(j))
+            val opts = frames.head.rows.head.row.options
+            opts.streamName should be("")
+            opts.generalizedStatements should be(true)
+            opts.rdfStar should be(true)
+            opts.maxNameTableSize should be(JellyOptions.bigStrict.maxNameTableSize)
+            opts.maxPrefixTableSize should be(JellyOptions.bigStrict.maxPrefixTableSize)
+            opts.maxDatatypeTableSize should be(JellyOptions.bigStrict.maxDatatypeTableSize)
+            opts.logicalType should be(LogicalStreamType.GRAPHS)
+            opts.version should be(1)
+          }
+      }
+
       "a file to file, lowered number of rows per frame" in withFullJenaFile { f =>
         withEmptyJellyFile { j =>
           val (out, err) =

--- a/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJellySpec.scala
+++ b/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJellySpec.scala
@@ -403,7 +403,9 @@ class RdfToJellySpec extends AnyWordSpec with TestFixtureHelper with Matchers:
               opts.maxDatatypeTableSize should be(JellyOptions.bigStrict.maxDatatypeTableSize)
               opts.logicalType should be(LogicalStreamType.FLAT_TRIPLES)
               opts.version should be(1)
-              RdfToJelly.getErrString should include("WARNING: The physical type is unspecified")
+              RdfToJelly.getErrString should include(
+                "WARNING: Logical type setting ignored because physical type is not set.",
+              )
             }
           },
           jenaLang = RDFLanguages.NTRIPLES,


### PR DESCRIPTION
Issue: #115 
For now, I have decided not to emit a warning when the logical type is set to something complex like GRAPHS, that expects framing, and the physical type is basically continuous, since the user can solve this through manipulating frame size. Let me know if you expect something different.