### PR TITLE
GH-93 Allow non streaming output formats in rdf from-jelly

### DIFF
--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfFromJelly.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfFromJelly.scala
@@ -5,7 +5,7 @@ import eu.neverblink.jelly.cli.*
 import eu.neverblink.jelly.cli.command.rdf.util.*
 import eu.neverblink.jelly.cli.command.rdf.util.RdfFormat.*
 import eu.neverblink.jelly.cli.util.args.IndexRange
-import eu.neverblink.jelly.cli.util.jena.StreamRdfBatchSink
+import eu.neverblink.jelly.cli.util.jena.StreamRdfBatchWriter
 import eu.neverblink.jelly.convert.jena.JenaConverterFactory
 import eu.neverblink.jelly.core.JellyOptions
 import eu.neverblink.jelly.core.RdfHandler.AnyStatementHandler
@@ -77,7 +77,7 @@ object RdfFromJelly extends RdfSerDesCommand[RdfFromJellyOptions, RdfFormat.Writ
       case j: RdfFormat.Jena.StreamWriteable =>
         Some((in, out) => jellyToLang(in, StreamRDFWriter.getWriterStream(out, j.jenaLang)))
       case j: RdfFormat.Jena.BatchWriteable =>
-        Some((in, out) => jellyToLang(in, StreamRdfBatchSink(out, j.jenaLang)))
+        Some((in, out) => jellyToLang(in, StreamRdfBatchWriter(out, j.jenaLang)))
       case RdfFormat.JellyText => Some(jellyBinaryToText)
 
   /** This method reads the Jelly file, rewrites it to specified format and writes it to some output

--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfFromJelly.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfFromJelly.scala
@@ -74,7 +74,7 @@ object RdfFromJelly extends RdfSerDesCommand[RdfFromJellyOptions, RdfFormat.Writ
       format: RdfFormat.Writeable,
   ): Option[(InputStream, OutputStream) => Unit] =
     format match
-      case j: RdfFormat.Jena.Writeable =>
+      case j: RdfFormat.Jena.StreamWriteable =>
         Some((in, out) => jellyToLang(in, StreamRDFWriter.getWriterStream(out, j.jenaLang)))
       case j: RdfFormat.Jena.BatchWriteable =>
         Some((in, out) => jellyToLang(in, StreamRdfBatchSink(out, j.jenaLang)))

--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfFromJelly.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfFromJelly.scala
@@ -31,8 +31,8 @@ object RdfFromJellyPrint extends RdfCommandPrintUtil[RdfFormat.Writeable]:
     "Otherwise, the program will exit with code 0.\n" +
     "Note: this command works in a streaming manner where possible and scales well to\n" +
     "large files. Non-streaming formats (e.g. RDF/XML) by default work on a\n" +
-    "frame-by-frame basis, but they can be combined into one object with the\n" +
-    "--combine option.",
+    "frame-by-frame basis, but they can be combined into one dataset with the\n" +
+    "--combine option. RDF/XML will only serialize the default model.",
 )
 @ArgsName("<file-to-convert>")
 case class RdfFromJellyOptions(
@@ -53,7 +53,7 @@ case class RdfFromJellyOptions(
     )
     takeFrames: String = "",
     @HelpMessage(
-      "Add to combine the results into one object, when using a non-streaming output format. " +
+      "Add to combine the results into one dataset, when using a non-streaming output format. " +
         "Ignored otherwise. Take care with input size, as this option will load everything into memory.",
     )
     combine: Boolean = false,

--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/util/RdfFormat.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/util/RdfFormat.scala
@@ -16,36 +16,36 @@ object RdfFormat:
     val jenaLang: Lang
 
   object Jena:
-    sealed trait Writeable extends Jena, RdfFormat.Writeable
+    sealed trait StreamWriteable extends Jena, RdfFormat.Writeable
     sealed trait Readable extends Jena, RdfFormat.Readable
     sealed trait BatchWriteable extends Jena, RdfFormat.Writeable
 
-  case object NQuads extends RdfFormat.Jena.Writeable, RdfFormat.Jena.Readable:
+  case object NQuads extends RdfFormat.Jena.StreamWriteable, RdfFormat.Jena.Readable:
     override val fullName: String = "N-Quads"
     override val cliOptions: List[String] = List("nq", "nquads")
     override val jenaLang: Lang = RDFLanguages.NQUADS
 
-  case object NTriples extends RdfFormat.Jena.Writeable, RdfFormat.Jena.Readable:
+  case object NTriples extends RdfFormat.Jena.StreamWriteable, RdfFormat.Jena.Readable:
     override val fullName: String = "N-Triples"
     override val cliOptions: List[String] = List("nt", "ntriples")
     override val jenaLang: Lang = RDFLanguages.NTRIPLES
 
-  case object Turtle extends RdfFormat.Jena.Writeable, RdfFormat.Jena.Readable:
+  case object Turtle extends RdfFormat.Jena.StreamWriteable, RdfFormat.Jena.Readable:
     override val fullName: String = "Turtle"
     override val cliOptions: List[String] = List("ttl", "turtle")
     override val jenaLang: Lang = RDFLanguages.TURTLE
 
-  case object TriG extends RdfFormat.Jena.Writeable, RdfFormat.Jena.Readable:
+  case object TriG extends RdfFormat.Jena.StreamWriteable, RdfFormat.Jena.Readable:
     override val fullName: String = "TriG"
     override val cliOptions: List[String] = List("trig")
     override val jenaLang: Lang = RDFLanguages.TRIG
 
-  case object RdfProto extends RdfFormat.Jena.Writeable, RdfFormat.Jena.Readable:
+  case object RdfProto extends RdfFormat.Jena.StreamWriteable, RdfFormat.Jena.Readable:
     override val fullName: String = "RDF Protobuf"
     override val cliOptions: List[String] = List("jenaproto", "jena-proto")
     override val jenaLang: Lang = RDFLanguages.RDFPROTO
 
-  case object Thrift extends RdfFormat.Jena.Writeable, RdfFormat.Jena.Readable:
+  case object Thrift extends RdfFormat.Jena.StreamWriteable, RdfFormat.Jena.Readable:
     override val fullName: String = "RDF Thrift"
     override val cliOptions: List[String] = List("jenathrift", "jena-thrift")
     override val jenaLang: Lang = RDFLanguages.RDFTHRIFT

--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/util/RdfFormat.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/util/RdfFormat.scala
@@ -18,6 +18,7 @@ object RdfFormat:
   object Jena:
     sealed trait Writeable extends Jena, RdfFormat.Writeable
     sealed trait Readable extends Jena, RdfFormat.Readable
+    sealed trait BatchWriteable extends Jena, RdfFormat.Writeable
 
   case object NQuads extends RdfFormat.Jena.Writeable, RdfFormat.Jena.Readable:
     override val fullName: String = "N-Quads"
@@ -49,12 +50,12 @@ object RdfFormat:
     override val cliOptions: List[String] = List("jenathrift", "jena-thrift")
     override val jenaLang: Lang = RDFLanguages.RDFTHRIFT
 
-  case object RdfXml extends RdfFormat.Jena.Readable:
+  case object RdfXml extends RdfFormat.Jena.Readable, RdfFormat.Jena.BatchWriteable:
     override val fullName: String = "RDF/XML"
     override val cliOptions: List[String] = List("rdfxml", "rdf-xml")
     override val jenaLang: Lang = RDFLanguages.RDFXML
 
-  case object JsonLd extends RdfFormat.Jena.Readable:
+  case object JsonLd extends RdfFormat.Jena.Readable, RdfFormat.Jena.BatchWriteable:
     override val fullName: String = "JSON-LD"
     override val cliOptions: List[String] = List("jsonld", "json-ld")
     override val jenaLang: Lang = RDFLanguages.JSONLD

--- a/src/main/scala/eu/neverblink/jelly/cli/util/jena/StreamRdfBatchSink.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/util/jena/StreamRdfBatchSink.scala
@@ -1,0 +1,25 @@
+package eu.neverblink.jelly.cli.util.jena
+
+import org.apache.jena.riot.system.StreamRDF
+import org.apache.jena.rdf.model.ModelFactory
+import org.apache.jena.sparql.core.Quad
+import org.apache.jena.graph.Triple
+import org.apache.jena.rdf.model.Model
+import org.apache.jena.riot.system.StreamRDFLib
+import java.io.OutputStream
+import org.apache.jena.riot.Lang
+import org.apache.jena.riot.RDFDataMgr
+
+/** A StreamRDF implementation that collects everything into a Model. When finishing, formats
+  * everything according to the lang, and emits it to the outputStream. This is meant to be a
+  * fallback for non-streaming RDF formats, as it requires all data to be loaded in memory.
+  */
+class StreamRdfBatchSink(val outputStream: OutputStream, val lang: Lang) extends StreamRDF:
+  private val model: Model = ModelFactory.createDefaultModel()
+  private val modelStream: StreamRDF = StreamRDFLib.graph(model.getGraph)
+  override def quad(quad: Quad): Unit = modelStream.quad(quad)
+  override def triple(triple: Triple): Unit = modelStream.triple(triple)
+  override def prefix(prefix: String, iri: String): Unit = modelStream.prefix(prefix, iri)
+  override def base(base: String): Unit = modelStream.base(base)
+  override def finish(): Unit = RDFDataMgr.write(outputStream, model, lang)
+  override def start(): Unit = ()

--- a/src/main/scala/eu/neverblink/jelly/cli/util/jena/StreamRdfBatchWriter.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/util/jena/StreamRdfBatchWriter.scala
@@ -24,7 +24,13 @@ class StreamRdfBatchWriter(val outputStream: OutputStream, val lang: Lang) exten
   override def finish(): Unit = writeOutput()
   override def start(): Unit = ()
   def writeOutput(): Unit =
-    if lang == Lang.RDFXML then
-      RDFDataMgr.write(outputStream, dataset.getDefaultModel, lang)
-    else
-      RDFDataMgr.write(outputStream, dataset, lang)
+    if lang == Lang.RDFXML then RDFDataMgr.write(outputStream, dataset.getDefaultModel, lang)
+    else RDFDataMgr.write(outputStream, dataset, lang)
+  def runAndOutput(runnable: StreamRDF => Unit): Unit = {
+    runnable(this)
+    writeOutput()
+  }
+
+class StreamRdfCombiningBatchWriter(outputStream: OutputStream, lang: Lang)
+    extends StreamRdfBatchWriter(outputStream, lang):
+  override def finish(): Unit = ()

--- a/src/main/scala/eu/neverblink/jelly/cli/util/jena/StreamRdfBatchWriter.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/util/jena/StreamRdfBatchWriter.scala
@@ -1,25 +1,30 @@
 package eu.neverblink.jelly.cli.util.jena
 
 import org.apache.jena.riot.system.StreamRDF
-import org.apache.jena.rdf.model.ModelFactory
 import org.apache.jena.sparql.core.Quad
 import org.apache.jena.graph.Triple
-import org.apache.jena.rdf.model.Model
 import org.apache.jena.riot.system.StreamRDFLib
 import java.io.OutputStream
 import org.apache.jena.riot.Lang
 import org.apache.jena.riot.RDFDataMgr
+import org.apache.jena.query.DatasetFactory
+import org.apache.jena.query.Dataset
 
 /** A StreamRDF implementation that collects everything into a Model. When finishing, formats
   * everything according to the lang, and emits it to the outputStream. This is meant to be a
   * fallback for non-streaming RDF formats, as it requires all data to be loaded in memory.
   */
 class StreamRdfBatchWriter(val outputStream: OutputStream, val lang: Lang) extends StreamRDF:
-  private val model: Model = ModelFactory.createDefaultModel()
-  private val modelStream: StreamRDF = StreamRDFLib.graph(model.getGraph)
-  override def quad(quad: Quad): Unit = modelStream.quad(quad)
-  override def triple(triple: Triple): Unit = modelStream.triple(triple)
-  override def prefix(prefix: String, iri: String): Unit = modelStream.prefix(prefix, iri)
-  override def base(base: String): Unit = modelStream.base(base)
-  override def finish(): Unit = RDFDataMgr.write(outputStream, model, lang)
+  protected val dataset: Dataset = DatasetFactory.create()
+  protected val datasetStream: StreamRDF = StreamRDFLib.dataset(dataset.asDatasetGraph())
+  override def quad(quad: Quad): Unit = datasetStream.quad(quad)
+  override def triple(triple: Triple): Unit = datasetStream.triple(triple)
+  override def prefix(prefix: String, iri: String): Unit = datasetStream.prefix(prefix, iri)
+  override def base(base: String): Unit = datasetStream.base(base)
+  override def finish(): Unit = writeOutput()
   override def start(): Unit = ()
+  def writeOutput(): Unit =
+    if lang == Lang.RDFXML then
+      RDFDataMgr.write(outputStream, dataset.getDefaultModel, lang)
+    else
+      RDFDataMgr.write(outputStream, dataset, lang)

--- a/src/main/scala/eu/neverblink/jelly/cli/util/jena/StreamRdfBatchWriter.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/util/jena/StreamRdfBatchWriter.scala
@@ -14,7 +14,7 @@ import org.apache.jena.riot.RDFDataMgr
   * everything according to the lang, and emits it to the outputStream. This is meant to be a
   * fallback for non-streaming RDF formats, as it requires all data to be loaded in memory.
   */
-class StreamRdfBatchSink(val outputStream: OutputStream, val lang: Lang) extends StreamRDF:
+class StreamRdfBatchWriter(val outputStream: OutputStream, val lang: Lang) extends StreamRDF:
   private val model: Model = ModelFactory.createDefaultModel()
   private val modelStream: StreamRDF = StreamRDFLib.graph(model.getGraph)
   override def quad(quad: Quad): Unit = modelStream.quad(quad)

--- a/src/test/scala/eu/neverblink/jelly/cli/command/helpers/DataGenHelper.scala
+++ b/src/test/scala/eu/neverblink/jelly/cli/command/helpers/DataGenHelper.scala
@@ -148,3 +148,14 @@ object DataGenHelper:
     RDFDataMgr.write(outputStream, dataset, jenaLang)
     val nQuadStream = new ByteArrayInputStream(outputStream.toByteArray)
     nQuadStream
+
+  def generateJellyInputStreamDataset(
+      nGraphs: Int,
+      nTriplesPerGraph: Int,
+      differentiator: String,
+  ): ByteArrayInputStream =
+    val model = generateDataset(nGraphs, nTriplesPerGraph, differentiator)
+    val outputStream = new ByteArrayOutputStream()
+    RDFDataMgr.write(outputStream, model, JellyLanguage.JELLY)
+    val jellyStream = new ByteArrayInputStream(outputStream.toByteArray)
+    jellyStream

--- a/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfFromJellySpec.scala
+++ b/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfFromJellySpec.scala
@@ -6,7 +6,6 @@ import eu.neverblink.jelly.cli.command.helpers.*
 import eu.neverblink.jelly.cli.command.rdf.util.RdfFormat
 import eu.neverblink.jelly.core.proto.v1.{PhysicalStreamType, RdfStreamFrame}
 import eu.neverblink.jelly.core.{JellyOptions, JellyTranscoderFactory}
-import org.apache.jena.riot.RDFLanguages
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -231,8 +230,8 @@ class RdfFromJellySpec extends AnyWordSpec with Matchers with TestFixtureHelper:
           val newModel = ModelFactory.createDefaultModel()
           RDFDataMgr.read(newModel, new ByteArrayInputStream(out.getBytes()), lang.jenaLang)
           model.isIsomorphicWith(newModel) shouldBe true
+        }
       }
-    }
 
     "throw proper exception" when {
       "input file is not found" in {
@@ -354,34 +353,6 @@ class RdfFromJellySpec extends AnyWordSpec with Matchers with TestFixtureHelper:
           RdfFromJelly.getErrString should include(msg.getMessage)
           exception.code should be(1)
         }
-      }
-
-      "readable but not writable format supplied" in withFullJellyFile { j =>
-        withEmptyJenaFile(
-          testCode = { q =>
-            val exception =
-              intercept[ExitException] {
-                RdfFromJelly.runTestCommand(
-                  List(
-                    "rdf",
-                    "from-jelly",
-                    j,
-                    "--to",
-                    q,
-                    "--out-format",
-                    RdfFormat.RdfXml.cliOptions.head,
-                  ),
-                )
-              }
-            val msg = InvalidFormatSpecified(
-              RdfFormat.RdfXml.cliOptions.head,
-              RdfFromJellyPrint.validFormatsString,
-            )
-            RdfFromJelly.getErrString should include(msg.getMessage)
-            exception.code should be(1)
-          },
-          jenaLang = RDFLanguages.RDFXML,
-        )
       }
 
       "invalid --take-frames argument provided" in {

--- a/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfFromJellySpec.scala
+++ b/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfFromJellySpec.scala
@@ -248,9 +248,10 @@ class RdfFromJellySpec extends AnyWordSpec with Matchers with TestFixtureHelper:
           RDFDataMgr.read(newDataset, new ByteArrayInputStream(out.getBytes()), lang.jenaLang)
           newDataset.isEmpty shouldBe false
           dataset.getDefaultModel.isIsomorphicWith(newDataset.getDefaultModel) shouldBe true
-          dataset.getNamedModel("http://example.org/graph/2").isIsomorphicWith(
-            newDataset.getNamedModel("http://example.org/graph/2"),
-          ) shouldBe true
+          if lang != RdfFormat.RdfXml then
+            dataset.getNamedModel("http://example.org/graph/2").isIsomorphicWith(
+              newDataset.getNamedModel("http://example.org/graph/2"),
+            ) shouldBe true
         }
 
         s"multiple frames input stream to output ${lang.fullName} stream without --combine flag" in {


### PR DESCRIPTION
Closes #93 

I add `StreamRdfBatchSink` which implements `StreamRDF`. The class builds a Jena Model while receiving events, and when finishing, serializes the model into a selected format and streams it out. This is plugged into the `from-jelly` command with a new format `RdfFormat.Jena.BatchWriteable`, and by moving the writer initialization out of `jellyToLang` to the call-sites. I add tests for checking graph isomorphism for both rdfxml and jsonld, and remove the test for the non-streaming format error, as there are no longer any non-writeable formats defined.