### PR TITLE
rdf to-jelly: preserve blank node IDs

### DIFF
--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJelly.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJelly.scala
@@ -10,6 +10,7 @@ import eu.neverblink.jelly.convert.jena.JenaConverterFactory
 import eu.neverblink.jelly.convert.jena.riot.{JellyFormatVariant, JellyLanguage, JellyStreamWriter}
 import eu.neverblink.jelly.core.proto.google.v1 as google
 import eu.neverblink.jelly.core.proto.v1.{LogicalStreamType, PhysicalStreamType, RdfStreamOptions}
+import org.apache.jena.riot.lang.LabelToNode
 import org.apache.jena.riot.system.StreamRDFWriter
 import org.apache.jena.riot.{Lang, RDFParser, RIOT}
 
@@ -159,7 +160,10 @@ object RdfToJelly extends RdfSerDesCommand[RdfToJellyOptions, RdfFormat.Readable
             .build()
           JellyStreamWriter(JenaConverterFactory.getInstance(), variant, outputStream)
 
-    RDFParser.source(inputStream).lang(jenaLang).parse(jellyWriter)
+    RDFParser.source(inputStream)
+      .lang(jenaLang)
+      .labelToNode(LabelToNode.createUseLabelAsGiven())
+      .parse(jellyWriter)
     jellyWriter.finish()
 
   /** Convert Jelly text to Jelly binary.


### PR DESCRIPTION
Previously blank node IDs were reassigned to new ones, drawing from some hashed in-memory pool. This unnecessarily wasted resources (we can keep the original IDs, they are fine for our use case), made a mess in the output, and could potentially lead to OOMs for very large files.

This somewhat speeds up the conversion for files that contain blank nodes. For OSM data, I saw ~10% better throughput in converting Turtle to Jelly.

It's still not amazingly fast, mostly due to the Turtle parser, but I'm hesitant to mess with it further – we may break something important.