### PR TITLE
Move the installation script to use gzipped files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -84,5 +84,4 @@ else
   exit 1
 fi
 
-jelly-cli completions install > /dev/null
-eval "$(jelly-cli completions install --env)"
+jelly-cli completions install

--- a/install.sh
+++ b/install.sh
@@ -51,9 +51,10 @@ fi
 
 
 # Download the binary
-DOWNLOAD_URL="https://github.com/$REPO_BASE/releases/download/$TAG_NAME/$BINARY_NAME$ARCH_NAME"
+DOWNLOAD_URL="https://github.com/$REPO_BASE/releases/download/$TAG_NAME/$BINARY_NAME$ARCH_NAME.gz"
 echo "Downloading $BINARY_NAME from $DOWNLOAD_URL"
-curl -L "$DOWNLOAD_URL" -o "$INSTALL_DIR/jelly-cli"
+curl -L "$DOWNLOAD_URL" -o "$INSTALL_DIR/jelly-cli.gz"
+gzip -d "$INSTALL_DIR/jelly-cli.gz"
 CONTENT=$(wc -c "$INSTALL_DIR/jelly-cli"  | awk '{print $1}')
 if [ $CONTENT -lt 500 ]; then
   echo "Error: Failed to download the binary from $DOWNLOAD_URL"


### PR DESCRIPTION
Modifies the installation script to download gzipped files and decompress them locally. Tested on Windows WSL and on Linux via Google Colab, looks as expected
<img width="1144" height="530" alt="image" src="https://github.com/user-attachments/assets/c4165d07-8262-41e8-8c67-e9c536154fa0" />
Additionally corrected one tiny detail in the install file. Since the completions install command always asks the user to run `eval "$(jelly-cli completions install --env)"`, it made no sense to run it in the install.sh regardless. If we would like to completely silence the output from completions install and just do it ourselves, please let me know and I can correct it in a follow-up PR.