### PR TITLE
AoT builds: enable the SkipFlow optimization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,8 @@ lazy val graalOptions = Seq(
   "--features=eu.neverblink.jelly.cli.graal.ProtobufFeature",
   "-H:ReflectionConfigurationFiles=" + file("graal.json").getAbsolutePath,
   "-H:+AddAllCharsets", // TODO: only add necessary charsets github.com/Jelly-RDF/cli/issues/154
+  "-H:+TrackPrimitiveValues", // SkipFlow optimization -- will be default in GraalVM 25
+  "-H:+UsePredicates", // SkipFlow optimization -- will be default in GraalVM 25
 )
 
 lazy val root = (project in file("."))


### PR DESCRIPTION
Issue #195

Enable the SkipFlow optimization in AoT builds to save on binary size. Details: https://medium.com/graalvm/skipflow-producing-smaller-executables-with-graalvm-f18ca98279c2

This trimmed 2MB from the binary size:

```
$ ls -lh
-rwxrwxr-x 1 piotr piotr  46M Aug 22 21:16 jelly-cli-os
-rwxrwxr-x 1 piotr piotr  44M Aug 24 23:11 jelly-cli-skipflow
```

Throughput baseline:

```
$ time ./jelly-cli-os rdf transcode nanopubs.jelly > /dev/null

real    1m57,221s
user    1m47,978s
sys     0m9,163s
```

Throughput with this change applied:

```
$ time ./jelly-cli-skipflow rdf transcode nanopubs.jelly > /dev/null

real    1m56,017s
user    1m47,645s
sys     0m8,306s
```

So, no significant difference, but we saved some binary size.
