### PR TITLE
AoT optimization: trim out unused code

### DIFF
--- a/src/main/java/eu/neverblink/jelly/cli/graal/GraalSubstitutes.java
+++ b/src/main/java/eu/neverblink/jelly/cli/graal/GraalSubstitutes.java
@@ -1,0 +1,63 @@
+package eu.neverblink.jelly.cli.graal;
+
+import com.apicatalog.jsonld.JsonLdError;
+import com.apicatalog.jsonld.http.HttpClient;
+import com.apicatalog.jsonld.http.HttpResponse;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import java.net.URI;
+import java.security.Provider;
+import java.util.List;
+
+// Substitutions of classes and methods for GraalVM native image builds.
+// These try to remove things from the static analysis (and, in effect, from the final binary)
+// that we don't need in jelly-cli, and that would bloat the binary size.
+
+/**
+ * Class used by JSON-LD to make HTTP requests for contexts and stuff.
+ * That's a security risk by itself... but also, we don't have to support *every single*
+ * JSON-LD feature in jelly-cli.
+ */
+@Substitute
+@TargetClass(com.apicatalog.jsonld.http.DefaultHttpClient.class)
+final class DefaultHttpClientSubstitute {
+    @Substitute
+    public static HttpClient defaultInstance() {
+        return new HttpClient() {
+            @Override
+            public HttpResponse send(URI targetUri, String requestProfile) throws JsonLdError {
+                throw new UnsupportedOperationException(
+                    "jelly-cli binaries do not support making HTTP requests when processing JSON-LD documents. " +
+                    "If you need this functionality, please use the JAR version of jelly-cli."
+                );
+            }
+        };
+    }
+}
+
+/**
+ * Mostly needed for SPARQL over HTTP, which we don't do in jelly-cli.
+ */
+@Substitute
+@TargetClass(org.apache.jena.http.HttpLib.class)
+final class HttpLibSubstitute { }
+
+/**
+ * Also mostly needed for SPARQL over HTTP, which we don't do in jelly-cli.
+ */
+@Substitute
+@TargetClass(org.apache.jena.http.HttpEnv.class)
+final class HttpEnvSubstitute { }
+
+/**
+ * UUID generation is used by Jena for blank node IDs, but we can fall back to the default implementation.
+ */
+@Substitute
+@TargetClass(className = "sun.security.jca.ProviderList")
+final class ProviderListSubstitute { 
+    @Substitute
+    public List<Provider> providers() {
+        return List.of();
+    }
+}


### PR DESCRIPTION
Issue #195

Introduces compile-time substitutions that make it impossible for the program to reach code that is not really used in jelly-cli, but still bloats the binary size.

Notably, this excludes all HTTP and SSL code used by JSON-LD context resolvers (we don't have to support that...) and Jena SPARQL (this is not used at all). We also trim out unused cyphers, which were included due to Jena using UUIDs for blank nodes.

This reduces the binary size by a further 10MB:

```
$ ls -lh
-rwxrwxr-x 1 piotr piotr  44M Aug 24 23:11 jelly-cli-skipflow
-rwxrwxr-x 1 piotr piotr  34M Aug 24 23:42 jelly-cli-skipflow-substitutes
```

Baseline throughput:

```
$ time ./jelly-cli-skipflow rdf transcode nanopubs.jelly > /dev/null

real    1m56,017s
user    1m47,645s
sys     0m8,306s
```

With this change applied:

```
$ time ./jelly-cli-skipflow-substitutes rdf transcode nanopubs.jelly > /dev/null

real    1m56,843s
user    1m48,597s
sys     0m8,226s
```

So, throughput is basically the same.
