### PR TITLE
Remove all charsets from AoT builds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,9 @@ lazy val graalOptions = Seq(
 ).flatten ++ Seq(
   "--features=eu.neverblink.jelly.cli.graal.ProtobufFeature",
   "-H:ReflectionConfigurationFiles=" + file("graal.json").getAbsolutePath,
-  "-H:+AddAllCharsets", // TODO: only add necessary charsets github.com/Jelly-RDF/cli/issues/154
+  // Needed to skip initializing all charsets.
+  // See: https://github.com/Jelly-RDF/cli/issues/154
+  "--initialize-at-build-time=org.glassfish.json.UnicodeDetectingInputStream",
   "-H:+TrackPrimitiveValues", // SkipFlow optimization -- will be default in GraalVM 25
   "-H:+UsePredicates", // SkipFlow optimization -- will be default in GraalVM 25
 )

--- a/src/main/java/eu/neverblink/jelly/cli/graal/GraalSubstitutes.java
+++ b/src/main/java/eu/neverblink/jelly/cli/graal/GraalSubstitutes.java
@@ -3,10 +3,12 @@ package eu.neverblink.jelly.cli.graal;
 import com.apicatalog.jsonld.JsonLdError;
 import com.apicatalog.jsonld.http.HttpClient;
 import com.apicatalog.jsonld.http.HttpResponse;
+import com.oracle.svm.core.annotate.Delete;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.security.Provider;
 import java.util.List;
 
@@ -60,4 +62,15 @@ final class ProviderListSubstitute {
     public List<Provider> providers() {
         return List.of();
     }
+}
+
+/**
+ * Disable UTF-32LE support in JSON parsers, which we don't need.
+ * This allows us to avoid including all charsets in the native image, which saves quite a bit of space.
+ * See: https://github.com/Jelly-RDF/cli/issues/154
+ */
+@TargetClass(className = "org.glassfish.json.UnicodeDetectingInputStream")
+final class UnicodeDetectingInputStreamSubstitute {
+    @Delete
+    private static Charset UTF_32LE;
 }


### PR DESCRIPTION
Closes #154

It turned out that all these charsets were not really needed, they were only referenced in one gnarly class initializer that I patched here.

This reduced the binary size by another 5MB:

```
$ ls -lh
-rwxrwxr-x 1 piotr piotr  34M Aug 24 23:42 jelly-cli-skipflow-substitutes
-rwxrwxr-x 1 piotr piotr  29M Aug 25 00:07 jelly-cli-skipflow-substitutes-nocharset
```