### PR TITLE
AoT builds: use -O3 optimization level

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,8 +23,8 @@ lazy val graalOptions = Seq(
   // Remove this after moving to Scala 3.8
   if (scalaV.split('.')(1).toInt < 8) Seq("-J--sun-misc-unsafe-memory-access=allow") else Nil,
   // Do a fast build if it's a dev build
-  // For the release build, optimize for size and make a build report
-  if (isDevBuild) Seq("-Ob") else Seq("-Os", "--emit build-report"),
+  // For the release build, optimize for speed and make a build report
+  if (isDevBuild) Seq("-Ob") else Seq("-O3", "--emit build-report"),
 ).flatten ++ Seq(
   "--features=eu.neverblink.jelly.cli.graal.ProtobufFeature",
   "-H:ReflectionConfigurationFiles=" + file("graal.json").getAbsolutePath,
@@ -82,6 +82,6 @@ lazy val root = (project in file("."))
     // GraalVM settings
     Compile / mainClass := Some("eu.neverblink.jelly.cli.App"),
     // Do a fast build if it's a dev build
-    // For the release build, optimize for size and make a build report
+    // For the release build, optimize for speed and make a build report
     graalVMNativeImageOptions := graalOptions,
   )


### PR DESCRIPTION
Issue #195

Change compiler options to optimize for speed, instead of size. This should lead to more aggressive inlining, which greatly benefits Jelly, but will also inevitably increase the binary size.

This does increase the binary size by quite a bit (up to 63M uncompressed), but compared with the latest release (`jelly-cli-os`), when compressed that's just 6MB more:

```
$ ls -lh
-rwxrwxr-x 1 piotr piotr  63M Aug 25 00:15 jelly-cli-o3
-rwxrwxr-x 1 piotr piotr  25M Aug 25 00:15 jelly-cli-o3.gz
-rwxrwxr-x 1 piotr piotr  46M Aug 22 21:16 jelly-cli-os
-rwxrwxr-x 1 piotr piotr  19M Aug 22 21:16 jelly-cli-os.gz
-rwxrwxr-x 1 piotr piotr  29M Aug 25 00:07 jelly-cli-skipflow-substitutes-nocharset
-rwxrwxr-x 1 piotr piotr  11M Aug 25 00:07 jelly-cli-skipflow-substitutes-nocharset.gz
```

With -Os (baseline):

```
$ time ./jelly-cli-skipflow-substitutes-nocharset rdf transcode nanopubs.jelly > /dev/null

real    1m56,292s
user    1m47,591s
sys     0m8,667s
```

With -O3:

```
$ time ./jelly-cli-o3 rdf transcode nanopubs.jelly > /dev/null

real    1m3,072s
user    0m54,912s
sys     0m8,142s
```

So, it also increased throughput by almost 2x. I think that's worth the extra few megabytes, especially because jelly-cli users mostly care about throughput...