### PR TITLE
AoT builds: use the G1 garbage collector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,5 +85,4 @@ lazy val root = (project in file("."))
     // Do a fast build if it's a dev build
     // For the release build, optimize for speed and make a build report
     graalVMNativeImageOptions := graalOptions,
-    graalVMNativeImageCommand := "/opt/graalvm_2025_03/bin/native-image",
   )

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ lazy val graalOptions = Seq(
   // For the release build, optimize for speed and make a build report
   if (isDevBuild) Seq("-Ob") else Seq("-O3", "--emit build-report"),
 ).flatten ++ Seq(
+  "--gc=G1", // Use the faster, parallel G1 garbage collector
   "--features=eu.neverblink.jelly.cli.graal.ProtobufFeature",
   "-H:ReflectionConfigurationFiles=" + file("graal.json").getAbsolutePath,
   // Needed to skip initializing all charsets.
@@ -84,4 +85,5 @@ lazy val root = (project in file("."))
     // Do a fast build if it's a dev build
     // For the release build, optimize for speed and make a build report
     graalVMNativeImageOptions := graalOptions,
+    graalVMNativeImageCommand := "/opt/graalvm_2025_03/bin/native-image",
   )


### PR DESCRIPTION
Issue #195

Changes the GC for AoT builds from the default serial collector to G1, which is the only other available GC. G1 works largely in parallel, and while it's really designed to lower latency, in our case it also helps with throughput, because we get rid of long GC pauses.

This does increase the binary size, but we can try to squeeze something more out of it later (e.g., with PGOs – #198):

```
$ ls -lh
-rwxrwxr-x 1 piotr piotr  63M Aug 25 00:15 jelly-cli-o3
-rwxrwxr-x 1 piotr piotr  81M Aug 25 00:29 jelly-cli-o3-g1
-rwxrwxr-x 1 piotr piotr  31M Aug 25 00:29 jelly-cli-o3-g1.gz
-rwxrwxr-x 1 piotr piotr  25M Aug 25 00:15 jelly-cli-o3.gz
```

Baseline throughput:

```
$ time ./jelly-cli-o3 rdf transcode nanopubs.jelly > /dev/null

real    1m2,342s
user    0m54,066s
sys     0m8,228s


$ time ./jelly-cli-o3 rdf from-jelly nanopubs.jelly > /dev/null

real    3m31,301s
user    3m22,976s
sys     0m8,314s
```

With this change applied:

```
$ time ./jelly-cli-o3-g1 rdf transcode nanopubs.jelly > /dev/null

real    0m59,580s
user    0m53,008s
sys     0m7,868s


$ time ./jelly-cli-o3-g1 rdf from-jelly nanopubs.jelly > /dev/null

real    3m22,249s
user    3m15,588s
sys     0m7,893s
```

So, it's *a bit faster*.