### PR TITLE
Disable Jena IRI/literal validation by default

### DIFF
--- a/.github/workflows/aot-test.yml
+++ b/.github/workflows/aot-test.yml
@@ -32,11 +32,19 @@ jobs:
 
       - name: Test the binary
         run: |
-          target/graalvm-native-image/jelly-cli version && \
+          set -eux
+          
+          # See if it runs at all
+          target/graalvm-native-image/jelly-cli version
+          
+          # Make sure reflection works
+          target/graalvm-native-image/jelly-cli version | grep "JVM reflection: supported"
+          
+          # Test RDF conversions
           echo '_:b <http://t.org/> _:b .' | target/graalvm-native-image/jelly-cli \
             rdf to-jelly --in-format=nt > out.jelly && \
-            [ -s out.jelly ] &&
-            target/graalvm-native-image/jelly-cli \
+            [ -s out.jelly ]
+          target/graalvm-native-image/jelly-cli \
             rdf from-jelly --out-format=jelly-text out.jelly > out.txt && \
             [ -s out.txt ]
           target/graalvm-native-image/jelly-cli \
@@ -45,6 +53,9 @@ jobs:
           echo '{"@graph":[{"@id":"http://e.org/r","http://e.org/p":{"@value":"v"}}]}' | \
             target/graalvm-native-image/jelly-cli rdf to-jelly --in-format "jsonld" > jsonld.jelly && \
             [ -s jsonld.jelly ]
+          echo '<?xml version="1.0"?><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Seq rdf:about="http://example.org/favourite-fruit"></rdf:Seq></rdf:RDF>' | \
+            target/graalvm-native-image/jelly-cli rdf to-jelly --in-format "rdfxml" > rdfxml.jelly && \
+            [ -s rdfxml.jelly ]
 
       - name: Upload binary
         uses: actions/upload-artifact@v4

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Build and test
       shell: bash
-      run: sbt -v +test
+      run: sbt -v +test +test-serial:test
 
   test-assembly:
     runs-on: ubuntu-latest

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Build and test
       shell: bash
-      run: sbt -v +test +test-serial:test
+      run: sbt -v +test test-serial:test
 
   test-assembly:
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,8 @@ lazy val graalOptions = Seq(
   // For the release build, optimize for speed and make a build report
   if (isDevBuild) Seq("-Ob") else Seq("-O3", "--emit build-report"),
 ).flatten ++ Seq(
-  "--features=eu.neverblink.jelly.cli.graal.ProtobufFeature",
+  "--features=eu.neverblink.jelly.cli.graal.ProtobufFeature," +
+    "eu.neverblink.jelly.cli.graal.JenaInternalsFeature",
   "-H:ReflectionConfigurationFiles=" + file("graal.json").getAbsolutePath,
   // Needed to skip initializing all charsets.
   // See: https://github.com/Jelly-RDF/cli/issues/154
@@ -84,4 +85,5 @@ lazy val root = (project in file("."))
     // Do a fast build if it's a dev build
     // For the release build, optimize for speed and make a build report
     graalVMNativeImageOptions := graalOptions,
+    graalVMNativeImageCommand := "/opt/graalvm_2025_03/bin/native-image",
   )

--- a/build.sbt
+++ b/build.sbt
@@ -85,5 +85,4 @@ lazy val root = (project in file("."))
     // Do a fast build if it's a dev build
     // For the release build, optimize for speed and make a build report
     graalVMNativeImageOptions := graalOptions,
-    graalVMNativeImageCommand := "/opt/graalvm_2025_03/bin/native-image",
   )

--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/util/RdfPerformanceOptions.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/util/RdfPerformanceOptions.scala
@@ -1,0 +1,12 @@
+package eu.neverblink.jelly.cli.command.rdf.util
+
+import caseapp.HelpMessage
+
+/** Performance-related options for RDF processing.
+  */
+case class RdfPerformanceOptions(
+    @HelpMessage(
+      "Enable term validation and IRI resolution (slower). Default: false for all commands except 'rdf validate'.",
+    )
+    validateTerms: Option[Boolean] = None,
+)

--- a/src/main/scala/eu/neverblink/jelly/cli/graal/JenaInternalsFeature.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/graal/JenaInternalsFeature.scala
@@ -1,0 +1,17 @@
+package eu.neverblink.jelly.cli.graal
+
+import org.apache.jena.graph.impl.LiteralLabel
+import org.graalvm.nativeimage.hosted.{Feature, RuntimeReflection}
+
+class JenaInternalsFeature extends Feature:
+  import Feature.*
+
+  override def getDescription: String =
+    "Registers Jena internals for reflection. Needed for JenaSystemOptions to disable a few " +
+      "checks during RDF parsing."
+
+  override def beforeAnalysis(access: BeforeAnalysisAccess): Unit =
+    val classes = classOf[LiteralLabel].getDeclaredClasses
+    val valueModeClass = classes.find(_.getSimpleName == "ValueMode").get
+    RuntimeReflection.register(valueModeClass)
+    RuntimeReflection.register(valueModeClass.getDeclaredField("LAZY"))

--- a/src/main/scala/eu/neverblink/jelly/cli/util/jena/JenaSystemOptions.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/util/jena/JenaSystemOptions.scala
@@ -1,0 +1,42 @@
+package eu.neverblink.jelly.cli.util.jena
+
+import org.apache.jena.graph.impl.LiteralLabel
+import org.apache.jena.irix.{IRIProviderAny, SystemIRIx}
+
+import scala.util.Try
+
+object JenaSystemOptions:
+  /** Enable faster parsing by disabling strict IRI and literal validation.
+    * @return
+    *   A Success if the operation was successful, or a Failure with the exception if not. The
+    *   operation may fail in environments where reflection is not supported. The failure can be
+    *   ignored, but parsing will be slower.
+    */
+  def disableTermValidation(): Try[Unit] =
+    toggle(false)
+
+  /** For use only in tests.
+    */
+  def resetTermValidation(): Try[Unit] =
+    toggle(true)
+
+  private def toggle(enable: Boolean): Try[Unit] =
+    val valueMode = if enable then
+      SystemIRIx.reset()
+      "EAGER"
+    else
+      // Set the IRI provider to one that does no validation or resolving whatsoever
+      SystemIRIx.setProvider(IRIProviderAny.stringProvider())
+      "LAZY"
+
+    // Disable/enable eager computation of literal values, which does strict checking.
+    // This requires reflection as the field is private static final.
+    Try {
+      val f = classOf[LiteralLabel].getDeclaredField("valueMode")
+      val valueModeClass =
+        classOf[LiteralLabel].getDeclaredClasses.find(_.getSimpleName == "ValueMode").get
+      val valueModeLazy = valueModeClass.getDeclaredField(valueMode)
+      valueModeLazy.setAccessible(true)
+      f.setAccessible(true)
+      f.set(null, valueModeLazy.get(null))
+    }

--- a/src/main/scala/eu/neverblink/jelly/cli/util/jena/riot/FastParserProfile.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/util/jena/riot/FastParserProfile.scala
@@ -1,0 +1,27 @@
+package eu.neverblink.jelly.cli.util.jena.riot
+
+import org.apache.jena.irix.IRIxResolver
+import org.apache.jena.riot.RIOT
+import org.apache.jena.riot.lang.LabelToNode
+import org.apache.jena.riot.system.*
+
+/** Jena RIOT parser profile with optimizations for speed:
+  *   - No IRI resolution
+  *   - No error logging
+  *   - Passing blank node labels as-is
+  *   - No extra checks
+  */
+final class FastParserProfile
+    extends ParserProfileStd(
+      FactoryRDFCaching(FactoryRDFCaching.DftNodeCacheSize, LabelToNode.createUseLabelAsGiven()),
+      ErrorHandlerFactory.errorHandlerNoLogging,
+      IRIxResolver.create().noBase().resolve(false).allowRelative(true).build(),
+      PrefixMapStd(),
+      RIOT.getContext,
+      false,
+      false,
+    ):
+
+  /** Skip IRI resolution for speed.
+    */
+  override def resolveIRI(uriStr: String, line: Long, col: Long): String = uriStr

--- a/src/main/scala/eu/neverblink/jelly/cli/util/jena/riot/RiotParserUtil.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/util/jena/riot/RiotParserUtil.scala
@@ -1,0 +1,27 @@
+package eu.neverblink.jelly.cli.util.jena.riot
+
+import org.apache.jena.riot.{Lang, RDFParser, RDFParserRegistry, RIOT}
+import org.apache.jena.riot.system.StreamRDF
+
+import java.io.InputStream
+
+/** Utility for creating Jena RDF parsers in jelly-cli.
+  */
+object RiotParserUtil:
+  def parse(
+      enableTermValidation: Boolean,
+      lang: Lang,
+      source: InputStream,
+      output: StreamRDF,
+  ): Unit =
+    if enableTermValidation then
+      // Standard parser with validation enabled
+      RDFParser.source(source)
+        .lang(lang)
+        .parse(output)
+    else
+      // Fast parser with validation disabled
+      RDFParserRegistry
+        .getFactory(lang)
+        .create(lang, FastParserProfile())
+        .read(source, "", lang.getContentType, output, RIOT.getContext)

--- a/src/test-serial/scala/eu/neverblink/jelly/cli/command/rdf/TermValidationSpec.scala
+++ b/src/test-serial/scala/eu/neverblink/jelly/cli/command/rdf/TermValidationSpec.scala
@@ -1,0 +1,204 @@
+package eu.neverblink.jelly.cli.command.rdf
+
+import eu.neverblink.jelly.cli.command.helpers.TestFixtureHelper
+import eu.neverblink.jelly.cli.command.rdf.RdfToJellySpec.readJellyFile
+import eu.neverblink.jelly.cli.command.rdf.util.RdfFormat
+import eu.neverblink.jelly.cli.util.jena.JenaSystemOptions
+import eu.neverblink.jelly.cli.{ExitException, JellyDeserializationError}
+import eu.neverblink.jelly.core.{JellyOptions, RdfProtoDeserializationError}
+import eu.neverblink.jelly.core.proto.v1.PhysicalStreamType
+import org.apache.jena.datatypes.DatatypeFormatException
+import org.apache.jena.shared.impl.JenaParameters
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.io.ByteArrayInputStream
+import scala.util.Try
+
+class TermValidationSpec extends AnyWordSpec, Matchers, TestFixtureHelper:
+
+  protected val testCardinality: Int = 33
+
+  val frame = {
+    import eu.neverblink.jelly.cli.command.helpers.RdfAdapter.*
+    rdfStreamFrame(
+      Seq(
+        rdfStreamRow(
+          JellyOptions.BIG_GENERALIZED.clone()
+            .setPhysicalType(PhysicalStreamType.TRIPLES)
+            .setVersion(1),
+        ),
+        rdfStreamRow(rdfNameEntry(0, "notgood://malformed iri")),
+        rdfStreamRow(rdfDatatypeEntry(0, "http://www.w3.org/2001/XMLSchema#date")),
+        rdfStreamRow(
+          rdfTriple(
+            "b1",
+            rdfIri(0, 0), // malformed IRI
+            rdfLiteral("2025-02-31", 1), // invalid date
+          ),
+        ),
+      ),
+    )
+  }
+  val frameBytes = frame.toByteArray
+
+  "RdfFromJelly" should {
+    "warm up" in {
+      // Pre-test needed to properly initialize the command for testing
+      Try {
+        RdfFromJelly.runTestCommand(List("rdf", "from-jelly", "--help"))
+      }
+    }
+
+    "term validation disabled (default)" in {
+      JenaSystemOptions.resetTermValidation()
+      JenaParameters.enableEagerLiteralValidation = true
+      RdfFromJelly.setStdIn(ByteArrayInputStream(frameBytes))
+      val (out, err) = RdfFromJelly.runTestCommand(
+        List("rdf", "from-jelly", "--out-format", RdfFormat.NQuads.cliOptions.head),
+      )
+      out.length should be > 0
+      out should include("<notgood://malformed")
+      err.isEmpty shouldBe true
+    }
+
+    "term validation disabled (explicit)" in {
+      JenaSystemOptions.synchronized {
+        JenaSystemOptions.resetTermValidation()
+        JenaParameters.enableEagerLiteralValidation = true
+        RdfFromJelly.setStdIn(ByteArrayInputStream(frameBytes))
+        val (out, err) = RdfFromJelly.runTestCommand(
+          List(
+            "rdf",
+            "from-jelly",
+            "--out-format",
+            RdfFormat.NQuads.cliOptions.head,
+            "--validate-terms=false",
+          ),
+        )
+        out.length should be > 0
+        out should include("<notgood://malformed")
+        err.isEmpty shouldBe true
+      }
+    }
+
+    "term validation enabled" in {
+      JenaSystemOptions.synchronized {
+        JenaSystemOptions.resetTermValidation()
+        // This is normally not set. We use it to make sure the invalid date literal is actually detected.
+        JenaParameters.enableEagerLiteralValidation = true
+        RdfFromJelly.setStdIn(ByteArrayInputStream(frameBytes))
+        val ex = intercept[ExitException] {
+          RdfFromJelly.runTestCommand(
+            List(
+              "rdf",
+              "from-jelly",
+              "--out-format",
+              RdfFormat.NQuads.cliOptions.head,
+              "--validate-terms=true",
+            ),
+          )
+        }
+        ex.cause.get shouldBe a[JellyDeserializationError]
+        ex.cause.get.getMessage should include("datatype")
+      }
+    }
+  }
+
+  "RdfToJelly" should {
+    val input =
+      "_:Bb1 <notgood://malformed\\u0020iri> \"lalala\"^^<http://www.w3.org/2001/XMLSchema#int> ."
+        .getBytes
+
+    "warm up" in {
+      // Pre-test needed to properly initialize the command for testing
+      Try {
+        RdfToJelly.runTestCommand(List("rdf", "to-jelly", "--help"))
+      }
+    }
+
+    "term validation disabled (default)" in {
+      JenaSystemOptions.resetTermValidation()
+      JenaParameters.enableEagerLiteralValidation = true
+      RdfToJelly.setStdIn(new ByteArrayInputStream(input))
+      val (out, err) = RdfToJelly.runTestCommand(
+        List("rdf", "to-jelly", "--in-format=nt"),
+      )
+      val newIn = new ByteArrayInputStream(RdfToJelly.getOutBytes)
+      val frame = readJellyFile(newIn)
+      frame.size should be(1)
+      frame.head.getRows.size() should be > 3
+      err shouldBe empty
+    }
+
+    "term validation disabled (explicit)" in {
+      JenaSystemOptions.resetTermValidation()
+      JenaParameters.enableEagerLiteralValidation = true
+      RdfToJelly.setStdIn(new ByteArrayInputStream(input))
+      val (out, err) = RdfToJelly.runTestCommand(
+        List("rdf", "to-jelly", "--in-format=nt", "--validate-terms=false"),
+      )
+      val newIn = new ByteArrayInputStream(RdfToJelly.getOutBytes)
+      val frame = readJellyFile(newIn)
+      frame.size should be(1)
+      frame.head.getRows.size() should be > 3
+      err shouldBe empty
+    }
+
+    "term validation enabled (explicit)" in {
+      JenaSystemOptions.resetTermValidation()
+      // This is normally not set. We use it to make sure the invalid date literal is actually detected.
+      JenaParameters.enableEagerLiteralValidation = true
+      RdfToJelly.setStdIn(new ByteArrayInputStream(input))
+      val e = intercept[ExitException] {
+        RdfToJelly.runTestCommand(
+          List("rdf", "to-jelly", "--in-format=nt", "--validate-terms=true"),
+        )
+      }
+      e.code should be(1)
+      e.cause.get shouldBe a[DatatypeFormatException]
+    }
+  }
+
+  "RdfValidate" should {
+    "warm up" in {
+      // Pre-test needed to properly initialize the command for testing
+      Try {
+        RdfValidate.runTestCommand(List("rdf", "validate", "--help"))
+      }
+    }
+
+    "term validation enabled (default)" in {
+      JenaSystemOptions.resetTermValidation()
+      JenaParameters.enableEagerLiteralValidation = true
+      RdfValidate.setStdIn(ByteArrayInputStream(frameBytes))
+      val e = intercept[ExitException] {
+        RdfValidate.runTestCommand(List("rdf", "validate"))
+      }
+      e.cause.get shouldBe a[RdfProtoDeserializationError]
+      e.cause.get.getMessage should include("datatype")
+    }
+
+    "term validation enabled (explicit)" in {
+      JenaSystemOptions.resetTermValidation()
+      JenaParameters.enableEagerLiteralValidation = true
+      RdfValidate.setStdIn(ByteArrayInputStream(frameBytes))
+      val e = intercept[ExitException] {
+        RdfValidate.runTestCommand(List("rdf", "validate", "--validate-terms=true"))
+      }
+      e.cause.get shouldBe a[RdfProtoDeserializationError]
+      e.cause.get.getMessage should include("datatype")
+    }
+
+    "term validation disabled" in {
+      JenaSystemOptions.resetTermValidation()
+      // This is normally not set. We use it to make sure the invalid date literal is actually detected.
+      JenaParameters.enableEagerLiteralValidation = true
+      RdfValidate.setStdIn(ByteArrayInputStream(frameBytes))
+      val (out, err) = RdfValidate.runTestCommand(
+        List("rdf", "validate", "--validate-terms=false"),
+      )
+      out shouldBe empty
+      err shouldBe empty
+    }
+  }

--- a/src/test/scala/eu/neverblink/jelly/cli/command/VersionSpec.scala
+++ b/src/test/scala/eu/neverblink/jelly/cli/command/VersionSpec.scala
@@ -12,4 +12,9 @@ class VersionSpec extends AnyWordSpec, Matchers:
         out should include("Jelly-JVM")
         out should include("Apache Jena")
       }
+
+      "report that reflection is supported" in {
+        val (out, err) = Version.runTestCommand(List(alias))
+        out should include("[X] JVM reflection: supported.")
+      }
     }

--- a/src/test/scala/eu/neverblink/jelly/cli/command/helpers/TestFixtureHelper.scala
+++ b/src/test/scala/eu/neverblink/jelly/cli/command/helpers/TestFixtureHelper.scala
@@ -1,10 +1,12 @@
 package eu.neverblink.jelly.cli.command.helpers
 
+import eu.neverblink.jelly.cli.util.jena.JenaSystemOptions
 import eu.neverblink.jelly.cli.util.jena.riot.CliRiot
 import eu.neverblink.jelly.convert.jena.riot.{JellyFormatVariant, JellyLanguage}
 import eu.neverblink.jelly.core.JellyOptions
 import org.apache.jena.graph.Triple
 import org.apache.jena.riot.{Lang, RDFDataMgr, RDFFormat, RDFLanguages, RDFWriter, RIOT}
+import org.apache.jena.shared.impl.JenaParameters
 import org.apache.jena.sparql.graph.GraphFactory
 import org.apache.jena.sys.JenaSystem
 import org.scalatest.BeforeAndAfterAll
@@ -130,3 +132,6 @@ trait TestFixtureHelper extends BeforeAndAfterAll:
 
   override def afterAll(): Unit =
     Files.deleteIfExists(tmpDir)
+    // Reset any Jena system options we might have changed during tests
+    JenaSystemOptions.resetTermValidation()
+    JenaParameters.enableEagerLiteralValidation = false

--- a/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfFromJellySpec.scala
+++ b/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfFromJellySpec.scala
@@ -4,10 +4,11 @@ import com.google.protobuf.InvalidProtocolBufferException
 import eu.neverblink.jelly.cli.*
 import eu.neverblink.jelly.cli.command.helpers.*
 import eu.neverblink.jelly.cli.command.rdf.util.RdfFormat
-import eu.neverblink.jelly.cli.util.jena.JenaSystemOptions
 import eu.neverblink.jelly.core.proto.v1.{PhysicalStreamType, RdfStreamFrame}
 import eu.neverblink.jelly.core.{JellyOptions, JellyTranscoderFactory}
 import org.apache.jena.query.DatasetFactory
+import org.apache.jena.rdf.model.ModelFactory
+import org.apache.jena.riot.RDFDataMgr
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -16,9 +17,6 @@ import java.nio.file.attribute.PosixFilePermissions
 import java.nio.file.{Files, Paths}
 import scala.io.Source
 import scala.util.Using
-import org.apache.jena.riot.RDFDataMgr
-import org.apache.jena.rdf.model.ModelFactory
-import org.apache.jena.shared.impl.JenaParameters
 
 class RdfFromJellySpec extends AnyWordSpec with Matchers with TestFixtureHelper:
 
@@ -404,86 +402,6 @@ class RdfFromJellySpec extends AnyWordSpec with Matchers with TestFixtureHelper:
         val cause = e.getCause.asInstanceOf[InvalidArgument]
         cause.argument should be("--take-frames")
         cause.argumentValue should be("invalid")
-      }
-    }
-
-    "handle term validation" when {
-      import RdfAdapter.*
-      val frame = rdfStreamFrame(
-        Seq(
-          rdfStreamRow(
-            JellyOptions.BIG_GENERALIZED.clone()
-              .setPhysicalType(PhysicalStreamType.TRIPLES)
-              .setVersion(1),
-          ),
-          rdfStreamRow(rdfNameEntry(0, "notgood://malformed iri")),
-          rdfStreamRow(rdfDatatypeEntry(0, "http://www.w3.org/2001/XMLSchema#date")),
-          rdfStreamRow(
-            rdfTriple(
-              "b1",
-              rdfIri(0, 0), // malformed IRI
-              rdfLiteral("2025-02-31", 1), // invalid date
-            ),
-          ),
-        ),
-      )
-      val frameBytes = frame.toByteArray
-
-      "term validation disabled (default)" in {
-        // Run in synchronized block to avoid interference with other tests
-        JenaSystemOptions.synchronized {
-          JenaSystemOptions.resetTermValidation()
-          JenaParameters.enableEagerLiteralValidation = true
-          RdfFromJelly.setStdIn(ByteArrayInputStream(frameBytes))
-          val (out, err) = RdfFromJelly.runTestCommand(
-            List("rdf", "from-jelly", "--out-format", RdfFormat.NQuads.cliOptions.head),
-          )
-          out.length should be > 0
-          out should include("<notgood://malformed")
-          err.isEmpty shouldBe true
-        }
-      }
-
-      "term validation disabled (explicit)" in {
-        JenaSystemOptions.synchronized {
-          JenaSystemOptions.resetTermValidation()
-          JenaParameters.enableEagerLiteralValidation = true
-          RdfFromJelly.setStdIn(ByteArrayInputStream(frameBytes))
-          val (out, err) = RdfFromJelly.runTestCommand(
-            List(
-              "rdf",
-              "from-jelly",
-              "--out-format",
-              RdfFormat.NQuads.cliOptions.head,
-              "--validate-terms=false",
-            ),
-          )
-          out.length should be > 0
-          out should include("<notgood://malformed")
-          err.isEmpty shouldBe true
-        }
-      }
-
-      "term validation enabled" in {
-        JenaSystemOptions.synchronized {
-          JenaSystemOptions.resetTermValidation()
-          // This is normally not set. We use it to make sure the invalid date literal is actually detected.
-          JenaParameters.enableEagerLiteralValidation = true
-          RdfFromJelly.setStdIn(ByteArrayInputStream(frameBytes))
-          val ex = intercept[ExitException] {
-            RdfFromJelly.runTestCommand(
-              List(
-                "rdf",
-                "from-jelly",
-                "--out-format",
-                RdfFormat.NQuads.cliOptions.head,
-                "--validate-terms=true",
-              ),
-            )
-          }
-          ex.cause.get shouldBe a[JellyDeserializationError]
-          ex.cause.get.getMessage should include("datatype")
-        }
       }
     }
   }

--- a/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJellySpec.scala
+++ b/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJellySpec.scala
@@ -3,16 +3,13 @@ package eu.neverblink.jelly.cli.command.rdf
 import eu.neverblink.jelly.cli.command.helpers.{DataGenHelper, TestFixtureHelper}
 import eu.neverblink.jelly.cli.command.rdf.util.RdfFormat
 import eu.neverblink.jelly.cli.*
-import eu.neverblink.jelly.cli.util.jena.JenaSystemOptions
 import eu.neverblink.jelly.convert.jena.riot.JellyLanguage
 import eu.neverblink.jelly.core.proto.v1.{LogicalStreamType, PhysicalStreamType, RdfStreamFrame}
 import eu.neverblink.jelly.core.JellyOptions
 import eu.neverblink.jelly.core.proto.google.v1 as google
 import eu.neverblink.jelly.core.utils.IoUtils
-import org.apache.jena.datatypes.DatatypeFormatException
 import org.apache.jena.rdf.model.{Model, ModelFactory}
 import org.apache.jena.riot.{RDFLanguages, RDFParser}
-import org.apache.jena.shared.impl.JenaParameters
 import org.apache.jena.sparql.core.DatasetGraphFactory
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -21,10 +18,7 @@ import java.io.{ByteArrayInputStream, FileInputStream, InputStream}
 import scala.jdk.CollectionConverters.*
 import scala.util.Using
 
-class RdfToJellySpec extends AnyWordSpec with TestFixtureHelper with Matchers:
-
-  protected val testCardinality: Int = 33
-
+object RdfToJellySpec:
   def translateJellyBack(inputStream: InputStream): Model =
     Using(inputStream) { content =>
       val newModel = ModelFactory.createDefaultModel()
@@ -44,6 +38,11 @@ class RdfToJellySpec extends AnyWordSpec with TestFixtureHelper with Matchers:
       case scala.util.Success(value) => value
       case scala.util.Failure(exception) => throw exception
     }
+
+class RdfToJellySpec extends AnyWordSpec with TestFixtureHelper with Matchers:
+  import RdfToJellySpec.*
+
+  protected val testCardinality: Int = 33
 
   "rdf to-jelly command" should {
     "handle conversion of NQuads to Jelly" when {
@@ -882,61 +881,6 @@ class RdfToJellySpec extends AnyWordSpec with TestFixtureHelper with Matchers:
               include("unsupported") and
               include("SUBJECT_GRAPHS/QUADS"),
           )
-      }
-    }
-
-    "handle term validation" when {
-      val input =
-        "_:Bb1 <notgood://malformed\\u0020iri> \"lalala\"^^<http://www.w3.org/2001/XMLSchema#int> ."
-          .getBytes
-
-      "term validation disabled (default)" in {
-        // Run in synchronized block to avoid interference with other tests
-        JenaSystemOptions.synchronized {
-          JenaSystemOptions.resetTermValidation()
-          JenaParameters.enableEagerLiteralValidation = true
-          RdfToJelly.setStdIn(new ByteArrayInputStream(input))
-          val (out, err) = RdfToJelly.runTestCommand(
-            List("rdf", "to-jelly", "--in-format=nt"),
-          )
-          val newIn = new ByteArrayInputStream(RdfToJelly.getOutBytes)
-          val frame = readJellyFile(newIn)
-          frame.size should be(1)
-          frame.head.getRows.size() should be > 3
-          err shouldBe empty
-        }
-      }
-
-      "term validation disabled (explicit)" in {
-        JenaSystemOptions.synchronized {
-          JenaSystemOptions.resetTermValidation()
-          JenaParameters.enableEagerLiteralValidation = true
-          RdfToJelly.setStdIn(new ByteArrayInputStream(input))
-          val (out, err) = RdfToJelly.runTestCommand(
-            List("rdf", "to-jelly", "--in-format=nt", "--validate-terms=false"),
-          )
-          val newIn = new ByteArrayInputStream(RdfToJelly.getOutBytes)
-          val frame = readJellyFile(newIn)
-          frame.size should be(1)
-          frame.head.getRows.size() should be > 3
-          err shouldBe empty
-        }
-      }
-
-      "term validation enabled (explicit)" in {
-        JenaSystemOptions.synchronized {
-          JenaSystemOptions.resetTermValidation()
-          // This is normally not set. We use it to make sure the invalid date literal is actually detected.
-          JenaParameters.enableEagerLiteralValidation = true
-          RdfToJelly.setStdIn(new ByteArrayInputStream(input))
-          val e = intercept[ExitException] {
-            RdfToJelly.runTestCommand(
-              List("rdf", "to-jelly", "--in-format=nt", "--validate-terms=true"),
-            )
-          }
-          e.code should be(1)
-          e.cause.get shouldBe a[DatatypeFormatException]
-        }
       }
     }
   }

--- a/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfValidateSpec.scala
+++ b/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfValidateSpec.scala
@@ -2,7 +2,6 @@ package eu.neverblink.jelly.cli.command.rdf
 
 import eu.neverblink.jelly.cli.command.helpers.{RdfAdapter, TestFixtureHelper}
 import eu.neverblink.jelly.cli.command.helpers.RdfAdapter.*
-import eu.neverblink.jelly.cli.util.jena.JenaSystemOptions
 import eu.neverblink.jelly.cli.{CriticalException, ExitException}
 import eu.neverblink.jelly.convert.jena.JenaConverterFactory
 import eu.neverblink.jelly.convert.jena.riot.JellyLanguage
@@ -11,7 +10,6 @@ import eu.neverblink.jelly.core.proto.v1.*
 import eu.neverblink.jelly.core.{JellyOptions, ProtoEncoder, RdfProtoDeserializationError}
 import org.apache.jena.graph.{NodeFactory, Triple}
 import org.apache.jena.riot.Lang
-import org.apache.jena.shared.impl.JenaParameters
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -726,70 +724,6 @@ class RdfValidateSpec extends AnyWordSpec, Matchers, TestFixtureHelper:
         RdfValidate.setStdIn(is)
         val (out, err) = RdfValidate.runTestCommand(List("rdf", "validate"))
         err shouldBe empty
-      }
-    }
-
-    "handle term validation" when {
-      import RdfAdapter.*
-      val frame = rdfStreamFrame(
-        Seq(
-          rdfStreamRow(
-            JellyOptions.BIG_GENERALIZED.clone()
-              .setPhysicalType(PhysicalStreamType.TRIPLES)
-              .setVersion(1),
-          ),
-          rdfStreamRow(rdfNameEntry(0, "notgood://malformed iri")),
-          rdfStreamRow(rdfDatatypeEntry(0, "http://www.w3.org/2001/XMLSchema#date")),
-          rdfStreamRow(
-            rdfTriple(
-              "b1",
-              rdfIri(0, 0), // malformed IRI
-              rdfLiteral("2025-02-31", 1), // invalid date
-            ),
-          ),
-        ),
-      )
-      val frameBytes = frame.toByteArray
-
-      "term validation enabled (default)" in {
-        // Run in synchronized block to avoid interference with other tests
-        JenaSystemOptions.synchronized {
-          JenaSystemOptions.resetTermValidation()
-          JenaParameters.enableEagerLiteralValidation = true
-          RdfValidate.setStdIn(ByteArrayInputStream(frameBytes))
-          val e = intercept[ExitException] {
-            RdfValidate.runTestCommand(List("rdf", "validate"))
-          }
-          e.cause.get shouldBe a[RdfProtoDeserializationError]
-          e.cause.get.getMessage should include("datatype")
-        }
-      }
-
-      "term validation enabled (explicit)" in {
-        JenaSystemOptions.synchronized {
-          JenaSystemOptions.resetTermValidation()
-          JenaParameters.enableEagerLiteralValidation = true
-          RdfValidate.setStdIn(ByteArrayInputStream(frameBytes))
-          val e = intercept[ExitException] {
-            RdfValidate.runTestCommand(List("rdf", "validate", "--validate-terms=true"))
-          }
-          e.cause.get shouldBe a[RdfProtoDeserializationError]
-          e.cause.get.getMessage should include("datatype")
-        }
-      }
-
-      "term validation disabled" in {
-        JenaSystemOptions.synchronized {
-          JenaSystemOptions.resetTermValidation()
-          // This is normally not set. We use it to make sure the invalid date literal is actually detected.
-          JenaParameters.enableEagerLiteralValidation = true
-          RdfValidate.setStdIn(ByteArrayInputStream(frameBytes))
-          val (out, err) = RdfValidate.runTestCommand(
-            List("rdf", "validate", "--validate-terms=false"),
-          )
-          out shouldBe empty
-          err shouldBe empty
-        }
       }
     }
   }


### PR DESCRIPTION
Closes #196

Validating IRIs and literals can take up even ~30–40% of runtime in `rdf to-jelly`. Most of the time we don't need that at all, because we only care about converting between formats, and not the validity of IRI schemas, or whether 30th February is a real date or not.

This disables validation by default in `to-jelly` and `from-jelly` commands, with the largest benefit being in the second case. Jelly by itself already bypasses some of these validations.

Lazy mapping of literals into value space should be fine, but we can't easily enable that from outside of Jena. I wrote a small routine using reflection to fix that. It may fail if reflection is not supported – e.g., if the JVM doesn't support it, or when Graal is misconfigured. We detect that and ignore it – the program will still work. You can run `jelly-cli version` to see if reflection (and, thus, maximum speed) is available on your platform.

Tested this with assist-iot-weather, 100K elements:

```
$ ls -lh
total 2,4G
-rw-rw-r-- 1 piotr piotr 217M Aug 25 14:59 assist-iot-weather-100k.jelly
-rw-rw-r-- 1 piotr piotr 2,1G Sep 11  2024 assist-iot-weather-100k.nt
-rwxrwxr-x 1 piotr piotr  63M Aug 25 14:52 jelly-cli-o3
-rwxrwxr-x 1 piotr piotr  63M Aug 25 14:54 jelly-cli-o3-novalidate
```

Baseline:

```
$ time ./jelly-cli-o3 rdf to-jelly assist-iot-weather-100k.nt > /dev/null

real    0m20,017s
user    0m19,655s
sys     0m0,360s

$ time ./jelly-cli-o3 rdf from-jelly assist-iot-weather-100k.jelly > /dev/null

real    0m8,177s
user    0m7,964s
sys     0m0,212s
```

```
$ time ./jelly-cli-o3-novalidate rdf to-jelly assist-iot-weather-100k.nt > /dev/null

real    0m12,358s
user    0m11,925s
sys     0m0,432s

$ time ./jelly-cli-o3-novalidate rdf from-jelly assist-iot-weather-100k.jelly > /dev/null

real    0m7,878s
user    0m7,725s
sys     0m0,152s
```

So, we are way faster on to-jelly, and slightly faster on from-jelly.
