### PR TITLE
docs: always install latest version via mise

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jelly-cli
 You can install `jelly-cli` on any platform (including Windows) using [mise](https://mise.jdx.dev/getting-started.html). Simply run:
 
 ```shell
-mise use -g 'ubi:Jelly-RDF/cli[exe=jelly-cli]'
+mise use -g 'ubi:Jelly-RDF/cli[exe=jelly-cli]@latest'
 jelly-cli
 ```
 


### PR DESCRIPTION
Otherwise, mise defaults to the version currently installed, and no upgrades are made.