### PR TITLE
README: remove misguided mise option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jelly-cli
 You can install `jelly-cli` on any platform (including Windows) using [mise](https://mise.jdx.dev/getting-started.html). Simply run:
 
 ```shell
-mise use -g 'ubi:Jelly-RDF/cli[exe=jelly-cli]@latest'
+mise use -g 'ubi:Jelly-RDF/cli[exe=jelly-cli]'
 jelly-cli
 ```
 


### PR DESCRIPTION
I was wrong, this is not how mise works. This doesn't help at all. You have to upgrade manually.