### PR TITLE
Fix BASE resolution for formats that support it

### DIFF
--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfValidate.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/RdfValidate.scala
@@ -250,8 +250,8 @@ object RdfValidate extends JellyCommand[RdfValidateOptions]:
     val output = StreamRdfCollector()
     Using.resource(IoUtil.inputStream(fileName)) { is =>
       RiotParserUtil.parse(
-        getOptions.rdfPerformanceOptions.validateTerms.getOrElse(true),
-        format.jenaLang,
+        getOptions.rdfPerformanceOptions.resolveIris,
+        format,
         is,
         output,
       )

--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/util/RdfFormat.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/util/RdfFormat.scala
@@ -6,6 +6,7 @@ import org.apache.jena.riot.{Lang, RDFLanguages}
 sealed trait RdfFormat:
   val fullName: String
   val cliOptions: List[String]
+  val supportsBaseIri: Boolean
 
 object RdfFormat:
 
@@ -29,6 +30,7 @@ object RdfFormat:
     override val fullName: String = "N-Quads"
     override val cliOptions: List[String] = List("nq", "nquads")
     override val jenaLang: Lang = RDFLanguages.NQUADS
+    override val supportsBaseIri: Boolean = false
 
   case object NTriples
       extends RdfFormat.Jena.StreamWriteable,
@@ -37,16 +39,19 @@ object RdfFormat:
     override val fullName: String = "N-Triples"
     override val cliOptions: List[String] = List("nt", "ntriples")
     override val jenaLang: Lang = RDFLanguages.NTRIPLES
+    override val supportsBaseIri: Boolean = false
 
   case object Turtle extends RdfFormat.Jena.StreamWriteable, RdfFormat.Jena.Readable:
     override val fullName: String = "Turtle"
     override val cliOptions: List[String] = List("ttl", "turtle")
     override val jenaLang: Lang = RDFLanguages.TURTLE
+    override val supportsBaseIri: Boolean = true
 
   case object TriG extends RdfFormat.Jena.StreamWriteable, RdfFormat.Jena.Readable:
     override val fullName: String = "TriG"
     override val cliOptions: List[String] = List("trig")
     override val jenaLang: Lang = RDFLanguages.TRIG
+    override val supportsBaseIri: Boolean = true
 
   case object RdfProto
       extends RdfFormat.Jena.StreamWriteable,
@@ -55,6 +60,7 @@ object RdfFormat:
     override val fullName: String = "RDF Protobuf"
     override val cliOptions: List[String] = List("jenaproto", "jena-proto")
     override val jenaLang: Lang = RDFLanguages.RDFPROTO
+    override val supportsBaseIri: Boolean = false
 
   case object Thrift
       extends RdfFormat.Jena.StreamWriteable,
@@ -63,16 +69,19 @@ object RdfFormat:
     override val fullName: String = "RDF Thrift"
     override val cliOptions: List[String] = List("jenathrift", "jena-thrift")
     override val jenaLang: Lang = RDFLanguages.RDFTHRIFT
+    override val supportsBaseIri: Boolean = false
 
   case object RdfXml extends RdfFormat.Jena.Readable, RdfFormat.Jena.BatchWriteable:
     override val fullName: String = "RDF/XML"
     override val cliOptions: List[String] = List("rdfxml", "rdf-xml")
     override val jenaLang: Lang = RDFLanguages.RDFXML
+    override val supportsBaseIri: Boolean = true
 
   case object JsonLd extends RdfFormat.Jena.Readable, RdfFormat.Jena.BatchWriteable:
     override val fullName: String = "JSON-LD"
     override val cliOptions: List[String] = List("jsonld", "json-ld")
     override val jenaLang: Lang = RDFLanguages.JSONLD
+    override val supportsBaseIri: Boolean = true
 
   // We do not ever want to write or read from Jelly to Jelly
   // So better not have it as Writeable or Readable, just mark that it's integrated into Jena
@@ -80,6 +89,7 @@ object RdfFormat:
     override val fullName: String = "Jelly binary"
     override val cliOptions: List[String] = List("jelly")
     override val jenaLang: Lang = JellyLanguage.JELLY
+    override val supportsBaseIri: Boolean = false
 
   case object JellyText
       extends RdfFormat,
@@ -89,6 +99,7 @@ object RdfFormat:
     override val fullName: String = "Jelly text"
     override val cliOptions: List[String] = List("jelly-text")
     val extension = ".jelly.txt"
+    override val supportsBaseIri: Boolean = false
 
   private val rdfFormats: List[RdfFormat] =
     List(NQuads, NTriples, JellyBinary, JellyText, Turtle, TriG, RdfProto, Thrift, RdfXml, JsonLd)

--- a/src/main/scala/eu/neverblink/jelly/cli/command/rdf/util/RdfPerformanceOptions.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/command/rdf/util/RdfPerformanceOptions.scala
@@ -6,7 +6,14 @@ import caseapp.HelpMessage
   */
 case class RdfPerformanceOptions(
     @HelpMessage(
-      "Enable term validation and IRI resolution (slower). Default: false for all commands except 'rdf validate'.",
+      "Resolve IRIs with regard to the base specified in the input document. " +
+        "Disabling this will result in faster parsing of Turtle, JSON-LD and RDF/XML, but will " +
+        "also potentially result in relative IRIs in the output. " +
+        "Default: true (ignored for formats that don't support base IRIs).",
+    )
+    resolveIris: Boolean = true,
+    @HelpMessage(
+      "Enable term validation (slower). Default: false for all commands except 'rdf validate'.",
     )
     validateTerms: Option[Boolean] = None,
 )

--- a/src/main/scala/eu/neverblink/jelly/cli/util/jena/JenaSystemOptions.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/util/jena/JenaSystemOptions.scala
@@ -1,12 +1,11 @@
 package eu.neverblink.jelly.cli.util.jena
 
 import org.apache.jena.graph.impl.LiteralLabel
-import org.apache.jena.irix.{IRIProviderAny, SystemIRIx}
 
 import scala.util.Try
 
 object JenaSystemOptions:
-  /** Enable faster parsing by disabling strict IRI and literal validation.
+  /** Enable faster parsing by disabling strict literal validation.
     * @return
     *   A Success if the operation was successful, or a Failure with the exception if not. The
     *   operation may fail in environments where reflection is not supported. The failure can be
@@ -21,13 +20,9 @@ object JenaSystemOptions:
     toggle(true)
 
   private def toggle(enable: Boolean): Try[Unit] =
-    val valueMode = if enable then
-      SystemIRIx.reset()
-      "EAGER"
-    else
-      // Set the IRI provider to one that does no validation or resolving whatsoever
-      SystemIRIx.setProvider(IRIProviderAny.stringProvider())
-      "LAZY"
+    val valueMode =
+      if enable then "EAGER"
+      else "LAZY"
 
     // Disable/enable eager computation of literal values, which does strict checking.
     // This requires reflection as the field is private static final.


### PR DESCRIPTION
Previously we lumped together IRI resolution with literal validation in the `--validate-terms` option, which is not great. For formats like TTL, JSON-LD and RDF/XML supporting BASE resolution is pretty much mandatory so as not to lose information specified in the file, and we were not doing that by default.

This introduces a new option, enabled by default for formats that support BASE, to resolve IRIs properly.

I've also despaghettified the validate-terms option a bit.

This will make parsing of RDF/XML, JSON-LD, and Turtle a bit slower by default, but you can restore previous performance with `--resolve-iris=false`.