### PR TITLE
Update to GraalVM 25

### DIFF
--- a/.github/workflows/aot-test.yml
+++ b/.github/workflows/aot-test.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'

--- a/build.sbt
+++ b/build.sbt
@@ -103,5 +103,4 @@ lazy val root = (project in file("."))
     // Do a fast build if it's a dev build
     // For the release build, optimize for speed and make a build report
     graalVMNativeImageOptions := graalOptions,
-    graalVMNativeImageCommand := "/opt/graalvm_2025_09/bin/native-image",
   )

--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,7 @@ lazy val graalOptions = Seq(
   "--initialize-at-build-time=org.glassfish.json.UnicodeDetectingInputStream",
   "-H:+TrackPrimitiveValues", // SkipFlow optimization -- will be default in GraalVM 25
   "-H:+UsePredicates", // SkipFlow optimization -- will be default in GraalVM 25
+  "-H:+MLCallCountProfileInference", // ML inference for hot/cold method detection
   // Make sure we don't include stuff that should be unreachable in the native image
   "-H:AbortOnMethodReachable=*UUID.randomUUID*",
   // Include XML error messages
@@ -102,4 +103,5 @@ lazy val root = (project in file("."))
     // Do a fast build if it's a dev build
     // For the release build, optimize for speed and make a build report
     graalVMNativeImageOptions := graalOptions,
+    graalVMNativeImageCommand := "/opt/graalvm_2025_09/bin/native-image",
   )


### PR DESCRIPTION
The new `-H:+MLCallCountProfileInference` option reduces the size of the binary by a lot – from 63.96 MB to 48.92 MB. But, as Oracle notes, this does come at a small cost to throughput.

GraalVM 24:

```
$ time jelly-cli rdf from-jelly ~/work/rb/jelly_full/digital-agenda-indicators.jelly > /dev/null

real    0m12,316s
user    0m10,773s
sys     0m1,542s
```

GraalVM 25:

```
$ time ./jelly-cli rdf from-jelly ~/work/rb/jelly_full/digital-agenda-indicators.jelly > /dev/null

real    0m14,501s
user    0m12,817s
sys     0m1,680s
```

I think it's worth it for most users... having a smaller binary should really be our priority. For maximum throughput we recommend the JAR builds anyway.