### PR TITLE
Truncate output files

### DIFF
--- a/src/main/scala/eu/neverblink/jelly/cli/util/io/IoUtil.scala
+++ b/src/main/scala/eu/neverblink/jelly/cli/util/io/IoUtil.scala
@@ -21,9 +21,9 @@ object IoUtil:
     if !file.canRead then throw InputFileInaccessible(fileName)
     FileInputStream(file)
 
-  /** Create output stream with extra error handling. If the file exists, it will append to it.
+  /** Create output stream with extra error handling. If the file exists, it will be truncated.
     * @param fileName
-    * @throws OutputFileExists
+    * @throws OutputFileCannotBeCreated
     * @return
     *   FileOutputStream
     */
@@ -33,4 +33,4 @@ object IoUtil:
     val parentFile = if (suppFile != null) suppFile else File(".")
     if !parentFile.canWrite || (file.exists() && !file.canWrite) then
       throw OutputFileCannotBeCreated(fileName)
-    FileOutputStream(file, true)
+    FileOutputStream(file)

--- a/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJellySpec.scala
+++ b/src/test/scala/eu/neverblink/jelly/cli/command/rdf/RdfToJellySpec.scala
@@ -70,6 +70,17 @@ class RdfToJellySpec extends AnyWordSpec with TestFixtureHelper with Matchers:
         }
       }
 
+      "a file to an already existing file, truncating it" in withFullJenaFile { f =>
+        withEmptyJellyFile { j =>
+          RdfToJelly.runTestCommand(List("rdf", "to-jelly", "--to", j, f))
+          val framesAfterFirstRun = readJellyFile(new FileInputStream(j)).size
+          RdfToJelly.runTestCommand(List("rdf", "to-jelly", "--to", j, f))
+          readJellyFile(new FileInputStream(j)).size should be(framesAfterFirstRun)
+          val content = translateJellyBack(new FileInputStream(j))
+          content.size should be(testCardinality)
+        }
+      }
+
       "input stream to output stream" in {
         val input = DataGenHelper.generateJenaInputStream(testCardinality)
         RdfToJelly.setStdIn(input)

--- a/src/test/scala/eu/neverblink/jelly/cli/util/io/IoUtilSpec.scala
+++ b/src/test/scala/eu/neverblink/jelly/cli/util/io/IoUtilSpec.scala
@@ -1,0 +1,43 @@
+package eu.neverblink.jelly.cli.util.io
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.nio.file.Files
+import scala.util.Using
+
+class IoUtilSpec extends AnyWordSpec, Matchers:
+  "IoUtil.outputStream" should {
+    "truncate an existing file" in {
+      val file = Files.createTempFile("jelly-cli", ".out")
+      try {
+        Files.write(file, "old content that is longer than the new one".getBytes)
+        Using(IoUtil.outputStream(file.toString)) { os =>
+          os.write("new".getBytes)
+        }
+        Files.readAllBytes(file) should be("new".getBytes)
+      } finally file.toFile.delete()
+    }
+
+    "truncate an existing file even when nothing is written" in {
+      val file = Files.createTempFile("jelly-cli", ".out")
+      try {
+        Files.write(file, "old content".getBytes)
+        Using(IoUtil.outputStream(file.toString)) { _ => () }
+        Files.size(file) should be(0)
+      } finally file.toFile.delete()
+    }
+
+    "create a file that does not exist yet" in {
+      val dir = Files.createTempDirectory("jelly-cli")
+      val file = dir.resolve("new-file.out")
+      try {
+        Using(IoUtil.outputStream(file.toString)) { os =>
+          os.write("content".getBytes)
+        }
+        Files.readAllBytes(file) should be("content".getBytes)
+      } finally
+        file.toFile.delete()
+        dir.toFile.delete()
+    }
+  }


### PR DESCRIPTION
I have no idea why we weren't doing that. It seems that this was the case since the first version of jelly-cli from March 2025. Basically every other similar tool truncates output files.

Anyway, this leads to appending to already filled files, which in the case of Jelly and a few other formats results in corrupted data.